### PR TITLE
fix cmake error

### DIFF
--- a/_lfsearch_/CMakeLists.txt
+++ b/_lfsearch_/CMakeLists.txt
@@ -47,7 +47,6 @@ set(MY_LIST
   lfs_editengine.lua
   lfs_editmain.lua
   lfs_editors.lua
-  lfs_message.lua
   lfs_mreplace.lua
   lfs_panels.lua
   lfs_rename.lua


### PR DESCRIPTION
```
-- LFSEARCH plugin enabled
CMake Error: File /tmp/build/luafar2m/_lfsearch_/plug/lfs_message.lua does not exist.
CMake Error at _lfsearch_/CMakeLists.txt:61 (configure_file):
  configure_file Problem configuring file
```
